### PR TITLE
Add block access methods to Game

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
 
     "example-plugins/simple",
     "example-plugins/query-entities",
+    "example-plugins/block-access",
 ]

--- a/crates/quill-common/src/block.rs
+++ b/crates/quill-common/src/block.rs
@@ -1,0 +1,49 @@
+/// Returned from `block_get`.
+///
+/// This is an FFI-safe representation of `Option<u16>`.
+#[repr(transparent)]
+pub struct BlockGetResult(u32);
+
+impl BlockGetResult {
+    pub fn new(block_id: Option<u16>) -> Self {
+        let tag = block_id.is_some() as u32;
+        let value = (tag << 16) | block_id.unwrap_or_default() as u32;
+        Self(value)
+    }
+
+    /// Gets the ID of the block.
+    pub fn get(self) -> Option<u16> {
+        if self.0 >> 16 == 0 {
+            None
+        } else {
+            Some(self.0 as u16)
+        }
+    }
+
+    pub fn to_u32(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_get_result_some() {
+        let result = BlockGetResult::new(Some(311));
+        assert_eq!(result.get(), Some(311));
+    }
+
+    #[test]
+    fn block_get_result_some_all_bits_set() {
+        let result = BlockGetResult::new(Some(u16::MAX));
+        assert_eq!(result.get(), Some(u16::MAX));
+    }
+
+    #[test]
+    fn block_get_result_none() {
+        let result = BlockGetResult::new(None);
+        assert_eq!(result.get(), None);
+    }
+}

--- a/crates/quill-common/src/lib.rs
+++ b/crates/quill-common/src/lib.rs
@@ -2,6 +2,7 @@
 mod utils;
 #[macro_use]
 pub mod component;
+pub mod block;
 pub mod components;
 pub mod entities;
 pub mod entity;

--- a/crates/quill-sys/src/lib.rs
+++ b/crates/quill-sys/src/lib.rs
@@ -20,7 +20,9 @@
 
 use std::mem::MaybeUninit;
 
-use quill_common::{entity::QueryData, EntityId, HostComponent, Pointer, PointerMut};
+use quill_common::{
+    block::BlockGetResult, entity::QueryData, EntityId, HostComponent, Pointer, PointerMut,
+};
 
 // The attribute macro transforms the block into either:
 // 1. On WASM, an extern "C" block defining functions imported from the host.
@@ -119,4 +121,19 @@ extern "C" {
     /// `builder` is consumed after this call.
     /// Reusing it is undefined behavior.
     pub fn entity_builder_finish(builder: u32) -> EntityId;
+
+    /// Gets the block at the given position.
+    ///
+    /// Returns `None` if the block's chunk is unloaded
+    /// or if the Y coordinate is out of bounds.
+    pub fn block_get(x: i32, y: i32, z: i32) -> BlockGetResult;
+
+    /// Sets the block at the given position.
+    ///
+    /// Returns `true` if successful and `false`
+    /// if the block's chunk is not loaded or
+    /// the Y coordinate is out of bounds.
+    ///
+    /// `block` is the vanilla ID of the block.
+    pub fn block_set(x: i32, y: i32, z: i32, block: u16) -> bool;
 }

--- a/crates/quill/Cargo.toml
+++ b/crates/quill/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 libcraft-core = { git = "https://github.com/feather-rs/libcraft" }
+libcraft-blocks = { git = "https://github.com/feather-rs/libcraft" }
 bincode = "1"
 bytemuck = "1"
 quill-sys = { path = "../quill-sys" }

--- a/crates/quill/src/lib.rs
+++ b/crates/quill/src/lib.rs
@@ -13,6 +13,8 @@ pub use game::Game;
 pub use setup::Setup;
 
 #[doc(inline)]
+pub use libcraft_blocks::{BlockKind, BlockState};
+#[doc(inline)]
 pub use libcraft_core::{
     BlockPosition, ChunkPosition, Enchantment, EnchantmentKind, Gamemode, Position,
 };

--- a/example-plugins/block-access/Cargo.toml
+++ b/example-plugins/block-access/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "block-access"
+version = "0.1.0"
+authors = ["caelunshun <caelunshun@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+quill = { path = "../../crates/quill" }

--- a/example-plugins/block-access/src/lib.rs
+++ b/example-plugins/block-access/src/lib.rs
@@ -1,0 +1,27 @@
+//! A plugin to demonstrate getting and setting blocks in the world.
+
+use quill::{entities::Player, BlockState, Game, Plugin, Position};
+
+pub struct BlockAccess;
+
+impl Plugin for BlockAccess {
+    fn enable(_game: &mut quill::Game, setup: &mut quill::Setup<Self>) -> Self {
+        setup.add_system(system);
+        Self
+    }
+
+    fn disable(self, _game: &mut quill::Game) {}
+}
+
+fn system(_plugin: &mut BlockAccess, game: &mut Game) {
+    // Set the blocks each player is standing on
+    // to bedrock.
+    for (_entity, (_, pos)) in game.query::<(&Player, &Position)>() {
+        let block_pos = pos.block();
+
+        // Note: In a real plugin, you should gracefully handle players being
+        // in unloaded chunks.
+        game.set_block(block_pos, BlockState::from_id(33).unwrap())
+            .expect("player is in unloaded chunk");
+    }
+}


### PR DESCRIPTION
Adds two methods to retrieve and set blocks.

In the future, we'll want to consider bulk block accesses for plugins like WorldEdit. For now, these simple functions will do the job.