### PR TITLE
Remove duplicate import

### DIFF
--- a/crates/quill/src/lib.rs
+++ b/crates/quill/src/lib.rs
@@ -19,8 +19,6 @@ pub use libcraft_core::{
     BlockPosition, ChunkPosition, Enchantment, EnchantmentKind, Gamemode, Position,
 };
 
-pub use libcraft_blocks::BlockState;
-
 #[doc(inline)]
 pub use libcraft_particles::{Particle, ParticleKind};
 


### PR DESCRIPTION
This duplicate import slipped through when I PR'd the particles. This pr resolves that.
Probably happened when I merged upstream into my branch.